### PR TITLE
Add console warnings for JSON parsing failures in workflow metadata

### DIFF
--- a/src/pages/RepositoryView.tsx
+++ b/src/pages/RepositoryView.tsx
@@ -34,7 +34,7 @@ const RepositoryView: React.FC<RepositoryViewProps> = ({ onFlowSelect }) => {
                                 };
                             }
                         }
-                    } catch (e) { }
+                    } catch (e) { console.warn(`Failed to parse metadata for workflow "${row.name}":`, e); }
 
                     return {
                         id: `db-${row.id}`,

--- a/src/pages/StudioView.tsx
+++ b/src/pages/StudioView.tsx
@@ -39,7 +39,7 @@ const StudioView: React.FC<StudioViewProps> = () => {
             if (data) {
                 setLibrary(data.map((row: any) => {
                     let meta = { dept: 'General', color: 'from-slate-900', height: 28 };
-                    try { meta = JSON.parse(row.description).meta || meta; } catch (e) { }
+                    try { meta = JSON.parse(row.description).meta || meta; } catch (e) { console.warn(`Failed to parse metadata for workflow "${row.name}":`, e); }
                     return { id: row.id, name: row.name, dept: meta.dept, color: meta.color, height: meta.height };
                 }));
             }
@@ -164,7 +164,7 @@ const StudioView: React.FC<StudioViewProps> = () => {
                 const parsed = JSON.parse(data.description);
                 desc = parsed.desc || "";
                 steps = parsed.steps || [];
-            } catch (e) { }
+            } catch (e) { console.warn(`Failed to parse description for workflow "${data.name}":`, e); }
 
             setGeneratedResult({
                 title: data.name,


### PR DESCRIPTION
## Summary
This PR improves error visibility by adding console warnings when JSON parsing fails for workflow metadata and descriptions. Previously, parsing errors were silently caught and ignored, making it difficult to debug issues with malformed workflow data.

## Changes
- **RepositoryView.tsx**: Added console warning when failing to parse workflow metadata
- **StudioView.tsx**: Added console warnings in two locations:
  - When parsing metadata from workflow descriptions during library initialization
  - When parsing workflow description and steps data

## Implementation Details
Each warning message includes:
- A descriptive message indicating what failed to parse
- The workflow name for context
- The error object for debugging

This change maintains backward compatibility by still gracefully handling parsing errors while providing developers with visibility into data quality issues.

https://claude.ai/code/session_013bW2j5DYVNBRCdBvsrSJoB